### PR TITLE
Add Megatron-Deepspeed MoE generate_text example.

### DIFF
--- a/benchmark_model_distributed/backends/pt_ms_moe_distributed.py
+++ b/benchmark_model_distributed/backends/pt_ms_moe_distributed.py
@@ -1,0 +1,146 @@
+import gc
+import json
+import os
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+import deepspeed
+from huggingface_hub import snapshot_download
+from transformers import AutoConfig, AutoModelForCausalLM
+from transformers.models.bloom.modeling_bloom import BloomBlock as BloomBlock
+from transformers.utils import is_offline_mode
+
+from anubis_logger import logger
+from pt_hf_nlp_distributed import HuggingFaceNlpGenerativeBackend
+
+from megatron import get_args
+from megatron import print_rank_0
+from megatron import mpu
+from megatron.checkpointing import load_checkpoint
+from megatron.initialize import initialize_megatron
+from megatron.model import GPTModel
+from megatron.training import get_model
+from megatron.text_generation_utils import get_token_stream
+
+
+class MegatronHelper:
+    """Helper class for Megatron-LM"""
+
+    @staticmethod
+    def add_text_generate_args(parser):
+        """Text generation arguments."""
+        group = parser.add_argument_group(title="text generation")
+
+        group.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature.")
+        group.add_argument("--greedy", action="store_true", default=False, help="Use greedy sampling.")
+        group.add_argument("--top_p", type=float, default=0.0, help="Top p sampling.")
+        group.add_argument("--top_k", type=int, default=0, help="Top k sampling.")
+        group.add_argument("--out-seq-length", type=int, default=None, help="Size of the output generated text.")
+        group.add_argument(
+            "--recompute",
+            action="store_true",
+            help="During generation recompute all attention " "instead of using previously computed keys/values.",
+        )
+
+        return parser
+
+    @staticmethod
+    def init_megatron(run_config):
+        import sys
+
+        if run_config.dtype == "float16":
+            sys.argv += ("--fp16",)
+        if run_config.greedy:
+            sys.argv += ("--greedy",)
+        sys.argv += ("--micro-batch-size", str(run_config.batch_size))
+        sys.argv += ("--seq-length", str(run_config.seq_len))
+        sys.argv += ("--out-seq-length", str(run_config.max_new_tokens))
+
+        # Other arguments
+        sys.argv += ("--tokenizer-type", "GPT2BPETokenizer", "--tensor-model-parallel-size", "1", "--num-layers", "24")
+        sys.argv += ("--hidden-size", "1024", "--num-attention-heads", "16", "--max-position-embeddings", "1024")
+        sys.argv += ("--num-experts", "1", "--mlp-type", "standard", "--temperature", "1.0")
+        sys.argv += ("--top_p", "0.9", "--log-interval", "1", "--num-samples", "0", "--ds-inference")
+        sys.argv += ("--vocab-file", "moe_data/gpt2-vocab.json")
+        sys.argv += ("--merge-file", "moe_data/gpt2-merges.txt")
+        sys.argv += ("--load", "moe_data/checkpoints/gpt2_345m", "--sample-input-file", "sample_input.txt")
+
+        initialize_megatron(
+            extra_args_provider=MegatronHelper.add_text_generate_args,
+            args_defaults={"tokenizer_type": "GPT2BPETokenizer", "no_load_rng": True, "no_load_optim": True},
+            ignore_unknown_args=True,
+        )
+
+    @staticmethod
+    def model_provider(pre_process=True, post_process=True):
+        """Build the model."""
+
+        print_rank_0("building GPT model ...")
+        model = GPTModel(
+            num_tokentypes=0,
+            parallel_output=False,
+            pre_process=pre_process,
+            post_process=post_process,
+            return_moe_loss=False,
+        )  # we need to set "return_moe_loss" for the inference_mode
+        return model
+
+    @staticmethod
+    def ds_inference(model, args):
+        engine = deepspeed.init_inference(
+            model=model,
+            mp_size=args.tensor_model_parallel_size,
+            tensor_parallel={"mpu": mpu},
+            dtype=torch.half,
+            replace_with_kernel_inject=True,
+            moe_experts=args.num_experts,
+            moe_type=args.mlp_type,
+        )
+
+        return engine.module
+
+
+class MsMoeDeepSpeedBackend(HuggingFaceNlpGenerativeBackend):
+    def __init__(self, run_config):
+        super().__init__(run_config)
+
+        deepspeed.init_distributed("nccl")
+        self._rank = dist.get_rank()
+
+        # since we're using deepspeed, set to False avoid get error as below:
+        # AttributeError: 'DeepSpeedBloomInference' object has no attribute 'dtype'
+        # It is introduced by enable torch.autocast
+        self._amp_enabled = False
+
+        if self._dtype != torch.float16:
+            raise ValueError("Model microsoft/bloom-deepspeed-inference only supports fp16")
+
+        MegatronHelper.init_megatron(run_config)
+        self.megatron_args = get_args()
+        if self.megatron_args.num_layers_per_virtual_pipeline_stage is not None:
+            raise ValueError("Interleaved pipeline schedule is not yet supported for text generation.")
+
+    def load_model(self):
+        logger.info(f"Loading model {self._model_name}...")
+
+        model = get_model(MegatronHelper.model_provider)
+        if self.megatron_args.load is not None:
+            load_checkpoint(model, None, None)
+        self._model = model[0]
+
+        if self.megatron_args.ds_inference:
+            self._model = MegatronHelper.ds_inference(self._model, self.megatron_args)
+            print("> DeepSpeed Inference engine initialized")
+
+    def predict(self, input_tokens):
+        if isinstance(input_tokens[0], int):  # batch_size == 1
+            input_tokens = [input_tokens]
+        for token_stream in get_token_stream(self._model, input_tokens):
+            pass
+
+
+class BenchmarkBackend(MsMoeDeepSpeedBackend):
+    def __init__(self, run_config):
+        super(BenchmarkBackend, self).__init__(run_config)

--- a/benchmark_model_distributed/benchmarkers/benchmarker.py
+++ b/benchmark_model_distributed/benchmarkers/benchmarker.py
@@ -34,8 +34,14 @@ class Benchmarker(ABC):
         raise NotImplementedError()
 
     def _print_benchmark_input(self, input):
-        for k in input:
-            logger.info(F"Benchmark input data shape: {k}={input[k].shape}")
+        if isinstance(input, dict):
+            for k in input:
+                logger.info(f"Benchmark input data shape: {k}={input[k].shape}")
+        if isinstance(input, list):  # For MoE case
+            if isinstance(input[0], int):  # batch_size == 1
+                logger.info(f"Benchmark input data shape: [{len(input)}]")
+            else:
+                logger.info(f"Benchmark input data shape: [{len(input)}, {len(input[0])}]")
 
     def _collect_metrics(self):
         predict_times = []

--- a/benchmark_model_distributed/data_loaders/pt_moe_nlp.py
+++ b/benchmark_model_distributed/data_loaders/pt_moe_nlp.py
@@ -1,0 +1,41 @@
+import math
+import numpy as np
+
+from deepspeed.accelerator import get_accelerator
+from data_loader import DataLoader
+from megatron import get_tokenizer
+from pt_hf_nlp import INPUTS
+
+
+class MegatronNlpDataloader(DataLoader):
+    def __init__(self, run_config):
+        super().__init__(run_config)
+
+        self._tokenizer = get_tokenizer()
+        meet_seq_len_inputs = []
+
+        input_sentences = INPUTS
+        if run_config.batch_size > len(INPUTS):
+            input_sentences *= math.ceil(run_config.batch_size / len(input_sentences))
+
+        for sen in input_sentences:
+            token = self._tokenizer.tokenize(sen)
+            # repeat the token to seq_len if needed; otherwise truncate to seq_len
+            rp_times = math.ceil(run_config.seq_len / len(token))
+            new_token = token * rp_times
+            new_token = new_token[: run_config.seq_len]
+            meet_seq_len_inputs.append(new_token)
+
+        if len(meet_seq_len_inputs) >= run_config.total_sample_count:
+            self._loaded_data_x = meet_seq_len_inputs[: run_config.total_sample_count]
+        else:
+            for _ in range(run_config.total_sample_count):
+                self._loaded_data_x.append(meet_seq_len_inputs[np.random.randint(len(meet_seq_len_inputs))])
+
+    def make_batch(self, data_array, selected_indices):
+        return [data_array[i] for i in selected_indices]
+
+
+class BenchmarkDataLoader(MegatronNlpDataloader):
+    def __init__(self, run_config):
+        super(BenchmarkDataLoader, self).__init__(run_config)

--- a/benchmark_model_distributed/moe_data/prepare_moe_data.sh
+++ b/benchmark_model_distributed/moe_data/prepare_moe_data.sh
@@ -1,0 +1,14 @@
+# Run this script to download the data and model checkpoints for the benchmark.
+cd $(dirname $0)
+
+# Source: https://github.com/microsoft/Megatron-DeepSpeed/blob/main/dataset/download_vocab.sh
+wget https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-vocab.json
+wget https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-merges.txt
+
+# Source: https://github.com/microsoft/Megatron-DeepSpeed/blob/main/dataset/download_ckpt.sh
+mkdir -p checkpoints/gpt2_345m
+cd checkpoints/gpt2_345m
+wget --content-disposition https://api.ngc.nvidia.com/v2/models/nvidia/megatron_lm_345m/versions/v0.0/zip \
+    -O megatron_lm_345m_v0.0.zip
+unzip megatron_lm_345m_v0.0.zip
+rm megatron_lm_345m_v0.0.zip

--- a/benchmark_model_distributed/supported_models.py
+++ b/benchmark_model_distributed/supported_models.py
@@ -12,8 +12,10 @@ BENCHMARKER_MAPPING = {
     "nlp_generative": NlpGenerativeBenchmarker,
 }
 
+# backend, dataloader, benchmarker
 PT_HF_NLP_GENERATIVE_BENCHMARK_CONFIG = ["pt_hf_nlp_distributed", "pt_hf_nlp", "nlp_generative"]
 PT_MS_BLOOM_GENERATIVE_BENCHMARK_CONFIG = ["pt_ms_bloom_distributed", "pt_hf_nlp", "nlp_generative"]
+PT_MS_MOE_GENERATIVE_BENCHMARK_CONFIG = ["pt_ms_moe_distributed", "pt_moe_nlp", "nlp_generative"]
 
 SUPPORTED_MODELS = {
     "facebook/opt-1.3b": PT_HF_NLP_GENERATIVE_BENCHMARK_CONFIG,
@@ -26,4 +28,5 @@ SUPPORTED_MODELS = {
     "bigscience/bloom-7b1": PT_HF_NLP_GENERATIVE_BENCHMARK_CONFIG,
     "bigscience/bloom": PT_HF_NLP_GENERATIVE_BENCHMARK_CONFIG,
     "microsoft/bloom-deepspeed-inference-fp16": PT_MS_BLOOM_GENERATIVE_BENCHMARK_CONFIG,
+    "microsoft/moe-deepspeed-inference-fp16": PT_MS_MOE_GENERATIVE_BENCHMARK_CONFIG,
 }


### PR DESCRIPTION
- Add Megatron-Deepspeed MoE generate_text example.
- Add script to prepare necessary data and checkpoint files for the benchmark.

Command-line arguments are required to change model configs etc. in Megatron. Modify `sys.argv` to work around, avoid changing existing argument parsing.